### PR TITLE
RE-1191 Use JS implementation of console colours

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,3 +15,63 @@ document.observe("dom:loaded", function () {
     // Click logo, go home.
     $$('div.logo')[0].on('click', function(){ location = '/'; });
 });
+
+// From: https://github.com/jakubjosef/jenkins-ansi-color-js
+function DOMReady(fn) {
+    if (document.attachEvent ? document.readyState === "complete" : document.readyState !== "loading") {
+        fn();
+    } else {
+        document.addEventListener('DOMContentLoaded', fn);
+    }
+}
+
+function addScript(src, callback, async) {
+    var s = document.createElement('script');
+    s.setAttribute('src', src);
+    s.onload = callback;
+    if (async) s.async = true
+    document.body.appendChild(s);
+}
+
+DOMReady(function() {
+    var consoleOutputSelector = ".console-output";
+    if (document.querySelector(consoleOutputSelector)) {
+        // init ansi colors
+        addScript("https://cdn.jsdelivr.net/npm/ansi_up@2.0.2/ansi_up.js", function() {
+            var ansiUp = new AnsiUp,
+                $console = document.querySelector(consoleOutputSelector),
+                entities = {
+                    'amp': '&',
+                    'apos': '\'',
+                    '#x27': '\'',
+                    '#x2F': '/',
+                    '#39': '\'',
+                    '#47': '/',
+                    'lt': '<',
+                    'gt': '>',
+                    'nbsp': ' ',
+                    'quot': '"'
+                },
+                decodeHTMLEntities = function(text) {
+                    return text.replace(/&([^;]+);/gm, function(match, entity) {
+                        return entities[entity] || match
+                    })
+                },
+                colorizeFn = function() {
+                    $console.innerHTML = decodeHTMLEntities(ansiUp.ansi_to_html($console.innerHTML));
+                };
+
+            colorizeFn();
+            // create prototype.js global ajax handle responder
+            Ajax.Responders.register({
+                onComplete: function(req, res) {
+                    if (req.body.indexOf("start=") != -1 && res.status==200 && res.responseText != "") {
+                        colorizeFn();
+                    }
+                }
+            });
+        }, true);
+    }
+});
+
+// End jenkins-ansi-color-js


### PR DESCRIPTION
The ansiColors plugin uses Jenkins' console notes feature to apply
formatting to the console. Unfortunately this adds quite a lot of
data to every log line that uses ansi colour codes. When a Jenkins
job involves executing a large number of playbooks, the number of
console lines that include colour codes is significant.

This pull request provides an alternative, which is a javascript
implementation that converts the ansi codes to html formatting.
As the conversion is done client side, there is no need to store
additional metadata on the server. This means the ansiColor plugin
can be removed, but logs will still be colourised when viewed
in the browser.

Implementation taken from:
 https://github.com/jakubjosef/jenkins-ansi-color-js